### PR TITLE
シングルモードのスコア履歴取得APIの実装

### DIFF
--- a/docs/api_list.md
+++ b/docs/api_list.md
@@ -21,6 +21,7 @@
 | POST | `/api/single-results` | シングルモードのプレイ結果（ユーザーID・スコア・正答率など）を登録する |
 | GET | `/api/single-results/latest?userId=:userId` | 指定したユーザーの最近のシングルモード結果を1件取得する |
 | GET | `/api/single-results/rankings` | シングルモードのスコア順ランキングを取得する |
+| GET | `/api/single-results/history?userId=:userId` | 指定したユーザーのスコア履歴を取得する |
 
 ---
 

--- a/src/main/java/com/example/typing/controller/SingleModeController.java
+++ b/src/main/java/com/example/typing/controller/SingleModeController.java
@@ -1,6 +1,7 @@
 package com.example.typing.controller;
 
 import com.example.typing.dto.request.ScoreRequest;
+import com.example.typing.dto.response.SingleHistoryResponse;
 import com.example.typing.dto.response.SingleRankingResponse;
 import com.example.typing.entity.SingleResult;
 import com.example.typing.entity.Words;
@@ -80,5 +81,16 @@ public class SingleModeController {
     public ResponseEntity<SingleRankingResponse> getRankings() {
         SingleRankingResponse rankings = wordService.getRankings();
         return ResponseEntity.ok(rankings);
+    }
+
+    /**
+     * 【スコア履歴取得】
+     * 指定したユーザーのシングルモードスコア履歴を取得する
+     * データが存在しない場合は空配列を返す
+     */
+    @GetMapping("/single-results/history")
+    public ResponseEntity<SingleHistoryResponse> getHistory(@RequestParam Long userId) {
+        SingleHistoryResponse history = wordService.getHistory(userId);
+        return ResponseEntity.ok(history);
     }
 }

--- a/src/main/java/com/example/typing/dto/response/SingleHistoryResponse.java
+++ b/src/main/java/com/example/typing/dto/response/SingleHistoryResponse.java
@@ -1,0 +1,26 @@
+package com.example.typing.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SingleHistoryResponse {
+
+    private Integer bestScore;    // 最高スコア
+    private Double averageScore;  // 平均スコア
+    private Integer playCount;    // プレイ回数
+    private List<Entry> histories; // 履歴一覧（finished_at 降順）
+
+    @Data
+    @AllArgsConstructor
+    public static class Entry {
+        private LocalDateTime finishedAt;   // プレイ日時
+        private Integer score;       // スコア
+        private Integer accuracyRate; // 正答率（%）
+    }
+}

--- a/src/main/java/com/example/typing/repository/SingleResultRepository.java
+++ b/src/main/java/com/example/typing/repository/SingleResultRepository.java
@@ -3,7 +3,10 @@ package com.example.typing.repository;
 import com.example.typing.entity.SingleResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -92,4 +95,39 @@ public interface SingleResultRepository extends JpaRepository<SingleResult, Long
                     rr.finished_at DESC
                 """, nativeQuery = true)
         List<SingleRankingRow> findRankingsWithStats();
+
+        /**
+         * 履歴取得結果のマッピング用インターフェース
+         */
+        interface SingleHistoryRow {
+            LocalDateTime  getFinishedAt();   // プレイ日時
+            Integer getScore();        // スコア
+            Integer getAccuracyRate(); // 正答率（%）
+            Integer getBestScore();    // 最高スコア
+            Double  getAverageScore(); // 平均スコア
+            Integer getPlayCount();    // プレイ回数
+        }
+
+        /**
+         * 指定ユーザーの履歴・統計情報を一括取得
+         * - 履歴は finished_at 降順（新しい順）で返す
+         * - 退会済みユーザー（deleted_at IS NOT NULL）は除外
+         * - データなしの場合は空リストを返す
+         */
+        @Query(value = """
+                SELECT
+                    sr.finished_at,
+                    sr.score,
+                    sr.accuracy_rate,
+                    MAX(sr.score)  OVER () AS best_score,
+                    AVG(sr.score)  OVER () AS average_score,
+                    COUNT(*)       OVER () AS play_count
+                FROM single_results sr
+                JOIN users u
+                    ON u.id = sr.user_id
+                WHERE sr.user_id   = :userId
+                    AND u.deleted_at IS NULL
+                ORDER BY sr.finished_at DESC
+                """, nativeQuery = true)
+        List<SingleHistoryRow> findHistoryByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/typing/service/SingleModeService.java
+++ b/src/main/java/com/example/typing/service/SingleModeService.java
@@ -1,7 +1,9 @@
 package com.example.typing.service;
 
 import com.example.typing.entity.Words;
+import com.example.typing.repository.SingleResultRepository.SingleHistoryRow;
 import com.example.typing.repository.SingleResultRepository.SingleRankingRow;
+import com.example.typing.dto.response.SingleHistoryResponse;
 import com.example.typing.dto.response.SingleRankingResponse;
 import com.example.typing.entity.SingleResult;
 import com.example.typing.repository.WordRepository;
@@ -97,5 +99,36 @@ public class SingleModeService {
                 .toList();
 
         return new SingleRankingResponse(totalUsers, averageBestScore, rankings);
+    }
+
+    /**
+     * 指定ユーザーのプレイ履歴・統計情報を取得する
+     * - 履歴は finished_at 降順（新しい順）で返す
+     * - 最高スコア・平均スコア・プレイ回数を SQL で算出してレスポンスに含める
+     * - データが存在しない場合は空リスト・統計値 0 で返す
+     */
+    public SingleHistoryResponse getHistory(Long userId) {
+        List<SingleHistoryRow> singleHistories = singleResultRepository.findHistoryByUserId(userId);
+
+        // データなし
+        if (singleHistories.isEmpty()) {
+            return new SingleHistoryResponse(0, 0.0, 0, Collections.emptyList());
+        }
+
+        // 統計情報
+        SingleHistoryRow firstRow = singleHistories.get(0);
+        int bestScore = firstRow.getBestScore();
+        double averageScore = firstRow.getAverageScore();
+        int playCount = firstRow.getPlayCount();
+
+        // 履歴一覧
+        List<SingleHistoryResponse.Entry> histories = singleHistories.stream()
+                .map(row -> new SingleHistoryResponse.Entry(
+                        row.getFinishedAt(),
+                        row.getScore(),
+                        row.getAccuracyRate()))
+                .toList();
+
+        return new SingleHistoryResponse(bestScore, averageScore, playCount, histories);
     }
 }

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -16,6 +16,20 @@ INSERT INTO magic_words (magic_text, magic_reading, magic_target) VALUES
 ('ダークボルテックス', 'だーくぼるてっくす', 'da-kuborutekkusu'),
 ('ホーリーライトニング', 'ほーりーらいとにんぐ', 'ho-ri-raitoninngu');
 
+-- -- ユーザー1
+-- INSERT INTO users (id, name, email, password, icon_image, created_at, updated_at, deleted_at, background_image) VALUES
+-- (1, '佐藤 太郎', 'user1@example.com', '$2b$12$b36a83701f1c3191e19722d6f90274bc1b5501fe69ebf33313e44', NULL, '2025-05-01 09:00:00', '2025-05-01 09:00:00', NULL, 0);
+
+-- -- ユーザー1のシングルモード履歴（3件）
+-- INSERT INTO single_results (user_id, score, accuracy_rate, finished_at) VALUES
+-- (1, 1200, 95, '2025-05-01 10:00:00'),
+-- (1, 980,  88, '2025-05-03 14:30:00'),
+-- (1, 1500, 98, '2025-05-05 09:15:00');
+-- -- ユーザー1のシングルモード履歴（3件）
+-- INSERT INTO single_results (user_id, score, accuracy_rate, finished_at) VALUES
+-- (1, 1200, 95, '2025-05-01 10:00:00'),
+-- (1, 980,  88, '2025-05-03 14:30:00'),
+-- (1, 1500, 98, '2025-05-05 09:15:00');
 
 -- ============================================================
 -- モックデータ: users + single_results


### PR DESCRIPTION
# 概要
スコア履歴画面で、ユーザーごとのシングルモードのプレイ履歴を表示できるようにするため、履歴取得APIを実装しました。  
履歴一覧・最高スコア・平均スコア・プレイ回数をまとめて取得できるようになります。

---

# 実装したAPI一覧
| メソッド | URL | 説明 |
|---|---|---|
| GET | `/api/single-results/history?userId=:userId` | シングルモード スコア履歴取得 |

---

# 主な変更内容

## 1. スコア履歴取得API

### 対象API
```text
GET /api/single-results/history?userId=:userId
```

### 変更内容
- `single_results` テーブルと `users` テーブルを結合し、指定ユーザーの履歴一覧を取得します
- 並び順は `finished_at` 降順（新しいプレイが上位）で返します
- ウィンドウ関数（`MAX` / `AVG` / `COUNT`）を使用し、最高スコア・平均スコア・プレイ回数を1クエリで一括取得しています
- 論理削除済みユーザー（`deleted_at IS NOT NULL`）は除外しています
- データが存在しない場合は空配列・統計値0を返します

### レスポンスDTO
| フィールド | 型 | 説明 |
|---|---|---|
| `bestScore` | Integer | 最高スコア |
| `averageScore` | Double | 平均スコア |
| `playCount` | Integer | プレイ回数 |
| `histories` | List | 履歴リスト |
| `histories[].finishedAt` | LocalDateTime | プレイ日時 |
| `histories[].score` | Integer | スコア |
| `histories[].accuracyRate` | Integer | 正答率（%） |

---

# 確認方法

## アプリケーション起動
```bash
mvn spring-boot:run
```

## 動作確認用 cURL

### スコア履歴取得
```bash
curl -X GET "http://localhost:8080/api/single-results/history?userId=1"
```

---

# 仕様確認状況
- `GET /api/single-results/history?userId=:userId` で履歴情報が取得できること
- プレイ日時・スコア・正答率がレスポンスに含まれていること
- 最高スコア・平均スコア・プレイ回数がレスポンスに含まれていること
- `finished_at` 降順（新しい順）で履歴が返ること
- データが存在しない場合でもエラーにならず空配列・統計値0が返ること