### PR TITLE
パスワード変更時に現在のパスワード照合を追加

### DIFF
--- a/src/main/java/com/example/typing/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/example/typing/dto/request/UserUpdateRequest.java
@@ -14,6 +14,7 @@ public class UserUpdateRequest {
     @Email(message = "メールアドレスの形式が正しくありません")
     private String email;            // メールアドレス
 
+    @Size(max = 127, message = "現在のパスワードは127文字以内で入力してください")
     private String currentPassword;  // 現在のパスワード（パスワード変更時に必須）
 
     @Size(min = 8, max = 127, message = "パスワードは8文字以上127文字以内で入力してください")

--- a/src/main/java/com/example/typing/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/example/typing/dto/request/UserUpdateRequest.java
@@ -14,8 +14,10 @@ public class UserUpdateRequest {
     @Email(message = "メールアドレスの形式が正しくありません")
     private String email;            // メールアドレス
 
+    private String currentPassword;  // 現在のパスワード（パスワード変更時に必須）
+
     @Size(min = 8, max = 127, message = "パスワードは8文字以上127文字以内で入力してください")
-    private String password;         // パスワード
+    private String password;         // 新しいパスワード
 
     private String iconImage;        // アイコン画像URL
     private Integer backgroundImage; // 背景画像ID（0 or 1）

--- a/src/main/java/com/example/typing/exception/InvalidPasswordException.java
+++ b/src/main/java/com/example/typing/exception/InvalidPasswordException.java
@@ -1,0 +1,7 @@
+package com.example.typing.exception;
+
+public class InvalidPasswordException extends RuntimeException {
+    public InvalidPasswordException() {
+        super("現在のパスワードが正しくありません");
+    }
+}

--- a/src/main/java/com/example/typing/exception/UserExceptionHandler.java
+++ b/src/main/java/com/example/typing/exception/UserExceptionHandler.java
@@ -14,6 +14,14 @@ import java.util.Map;
 public class UserExceptionHandler {
 
     /**
+     * 400 現在のパスワードが正しくない
+     */
+    @ExceptionHandler(InvalidPasswordException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidPasswordException(InvalidPasswordException ex) {
+        return buildResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    /**
      * 401 認証失敗
      */
     @ExceptionHandler(AuthenticationFailedException.class)
@@ -55,8 +63,7 @@ public class UserExceptionHandler {
                 "timestamp", LocalDateTime.now().toString(),
                 "status", status.value(),
                 "error", status.getReasonPhrase(),
-                "message", message
-        );
+                "message", message);
         return ResponseEntity.status(status).body(body);
     }
 }

--- a/src/main/java/com/example/typing/service/UserService.java
+++ b/src/main/java/com/example/typing/service/UserService.java
@@ -5,6 +5,7 @@ import com.example.typing.dto.request.UserUpdateRequest;
 import com.example.typing.dto.response.UserResponse;
 import com.example.typing.entity.User;
 import com.example.typing.exception.EmailAlreadyExistsException;
+import com.example.typing.exception.InvalidPasswordException;
 import com.example.typing.exception.UserNotFoundException;
 import com.example.typing.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -89,8 +90,12 @@ public class UserService {
             user.setEmail(request.getEmail());
         }
 
-        // パスワードの更新（ハッシュ化）
+        // パスワードの更新（現在のパスワード照合 → ハッシュ化）
         if (request.getPassword() != null) {
+            if (request.getCurrentPassword() == null ||
+                !passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
+                throw new InvalidPasswordException();
+            }
             user.setPassword(passwordEncoder.encode(request.getPassword()));
         }
 


### PR DESCRIPTION
## 概要

パスワード変更時に、現在のパスワード照合処理を追加

## 対応内容

* 現在のパスワード入力チェックを追加
* 現在のパスワードが一致しない場合、エラーを返却するよう修正
* `InvalidPasswordException` を追加
* `UserExceptionHandler` に例外ハンドリングを追加

## 確認内容

* 現在のパスワードが正しい場合、パスワード変更できること
* 現在のパスワードが誤っている場合、エラーメッセージが返ること
