### PR TITLE
ユーザーアイコン画像アップロード機能を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 HELP.md
 target/
+uploads/
 .mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/

--- a/src/main/java/com/example/typing/config/StaticResourceConfig.java
+++ b/src/main/java/com/example/typing/config/StaticResourceConfig.java
@@ -1,0 +1,27 @@
+package com.example.typing.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Path;
+
+@Configuration
+public class StaticResourceConfig implements WebMvcConfigurer {
+
+    @Value("${app.upload-dir}")
+    private String uploadDir;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // アップロードした画像を /uploads/** でブラウザから参照できるようにする
+        String uploadLocation = Path.of(uploadDir).toAbsolutePath().normalize().toUri().toString();
+        if (!uploadLocation.endsWith("/")) {
+            uploadLocation += "/";
+        }
+
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations(uploadLocation);
+    }
+}

--- a/src/main/java/com/example/typing/controller/UserController.java
+++ b/src/main/java/com/example/typing/controller/UserController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api")
@@ -34,12 +35,28 @@ public class UserController {
      *
      * @param userId  パスパラメータ（ユーザーID）
      * @param request リクエストボディ（更新情報）
-     * @return 200 OK + UserResponse / 400 Bad Request / 404 Not Found / 409 Conflict
+     * @return 200 OK + UserResponse / 400 Bad Request / 404 Not Found / 409
+     *         Conflict
      */
     @PatchMapping("/users/{userId}")
     public ResponseEntity<UserResponse> updateUser(@PathVariable Long userId,
             @Valid @RequestBody UserUpdateRequest request) {
         UserResponse response = userService.updateUser(userId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 【ユーザーアイコン画像アップロード】
+     * 指定したユーザーのアイコン画像をアップロードする
+     *
+     * @param userId パスパラメータ（ユーザーID）
+     * @param file   multipart/form-data の画像ファイル
+     * @return 200 OK + UserResponse / 400 Bad Request / 404 Not Found
+     */
+    @PostMapping("/users/{userId}/icon")
+    public ResponseEntity<UserResponse> uploadUserIcon(@PathVariable Long userId,
+            @RequestParam("file") MultipartFile file) {
+        UserResponse response = userService.uploadUserIcon(userId, file);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/example/typing/exception/InvalidImageFileException.java
+++ b/src/main/java/com/example/typing/exception/InvalidImageFileException.java
@@ -1,0 +1,7 @@
+package com.example.typing.exception;
+
+public class InvalidImageFileException extends RuntimeException {
+    public InvalidImageFileException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/typing/exception/UserExceptionHandler.java
+++ b/src/main/java/com/example/typing/exception/UserExceptionHandler.java
@@ -22,6 +22,14 @@ public class UserExceptionHandler {
     }
 
     /**
+     * 400 画像ファイルが正しくない
+     */
+    @ExceptionHandler(InvalidImageFileException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidImageFileException(InvalidImageFileException ex) {
+        return buildResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    /**
      * 401 認証失敗
      */
     @ExceptionHandler(AuthenticationFailedException.class)

--- a/src/main/java/com/example/typing/service/UserService.java
+++ b/src/main/java/com/example/typing/service/UserService.java
@@ -5,16 +5,24 @@ import com.example.typing.dto.response.UserResponse;
 import com.example.typing.entity.OtpToken;
 import com.example.typing.entity.User;
 import com.example.typing.exception.EmailAlreadyExistsException;
+import com.example.typing.exception.InvalidImageFileException;
 import com.example.typing.exception.InvalidPasswordException;
 import com.example.typing.exception.UserNotFoundException;
 import com.example.typing.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
+import java.util.Locale;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +30,9 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+
+    @Value("${app.upload-dir}")
+    private String uploadDir;
 
     /**
      * 指定したIDのユーザーを取得する（論理削除済みを除外）
@@ -91,7 +102,7 @@ public class UserService {
         // パスワードの更新（現在のパスワード照合 → ハッシュ化）
         if (request.getPassword() != null) {
             if (request.getCurrentPassword() == null ||
-                !passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
+                    !passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
                 throw new InvalidPasswordException();
             }
             user.setPassword(passwordEncoder.encode(request.getPassword()));
@@ -113,6 +124,57 @@ public class UserService {
     }
 
     /**
+     * 【ユーザーアイコン画像アップロード】
+     * 画像ファイルを保存し、ユーザーの iconImage に配信用パスを保存する
+     *
+     * @param userId ユーザーID
+     * @param file   アップロードされた画像ファイル
+     * @return UserResponse
+     */
+    @Transactional
+    public UserResponse uploadUserIcon(Long userId, MultipartFile file) {
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        if (file == null || file.isEmpty()) {
+            throw new InvalidImageFileException("画像ファイルが空です");
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        String extension = getAllowedImageExtension(originalFilename);
+
+        Path userUploadDir = Path.of(uploadDir, "users", userId.toString());
+        Path iconPath = userUploadDir.resolve("icon." + extension);
+
+        try {
+            Files.createDirectories(userUploadDir);
+            Files.copy(file.getInputStream(), iconPath, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw new IllegalStateException("画像ファイルの保存に失敗しました", e);
+        }
+
+        String iconImage = "/uploads/users/" + userId + "/icon." + extension;
+        user.setIconImage(iconImage);
+
+        return new UserResponse(userRepository.save(user));
+    }
+
+    private String getAllowedImageExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            throw new InvalidImageFileException("画像ファイルの形式が正しくありません");
+        }
+
+        String extension = filename.substring(filename.lastIndexOf(".") + 1).toLowerCase(Locale.ROOT);
+
+        if (!extension.equals("png") && !extension.equals("jpg")
+                && !extension.equals("jpeg") && !extension.equals("webp")) {
+            throw new InvalidImageFileException("アップロードできる画像形式は png, jpg, jpeg, webp のみです");
+        }
+
+        return extension;
+    }
+
+    /**
      * 【ユーザー削除】
      * 指定したユーザーを論理削除する（deleted_at に削除日時をセット、email を無効化）
      *
@@ -123,7 +185,7 @@ public class UserService {
     public void deleteUser(Long userId) {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new UserNotFoundException(userId));
-                
+
         user.setEmail("deleted_" + userId + "@deleted");
         user.setDeletedAt(LocalDateTime.now());
         user.setUpdatedAt(LocalDateTime.now());

--- a/src/main/java/com/example/typing/service/UserService.java
+++ b/src/main/java/com/example/typing/service/UserService.java
@@ -12,11 +12,13 @@ import com.example.typing.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
 import java.util.Locale;
+import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -27,6 +29,8 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @RequiredArgsConstructor
 public class UserService {
+
+    private static final Set<String> ALLOWED_IMAGE_EXTENSIONS = Set.of("png", "jpg", "jpeg", "webp");
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
@@ -149,6 +153,7 @@ public class UserService {
         try {
             Files.createDirectories(userUploadDir);
             Files.copy(file.getInputStream(), iconPath, StandardCopyOption.REPLACE_EXISTING);
+            deleteOldIconFiles(userUploadDir, iconPath);
         } catch (IOException e) {
             throw new IllegalStateException("画像ファイルの保存に失敗しました", e);
         }
@@ -166,12 +171,21 @@ public class UserService {
 
         String extension = filename.substring(filename.lastIndexOf(".") + 1).toLowerCase(Locale.ROOT);
 
-        if (!extension.equals("png") && !extension.equals("jpg")
-                && !extension.equals("jpeg") && !extension.equals("webp")) {
+        if (!ALLOWED_IMAGE_EXTENSIONS.contains(extension)) {
             throw new InvalidImageFileException("アップロードできる画像形式は png, jpg, jpeg, webp のみです");
         }
 
         return extension;
+    }
+
+    private void deleteOldIconFiles(Path userUploadDir, Path currentIconPath) throws IOException {
+        try (DirectoryStream<Path> iconFiles = Files.newDirectoryStream(userUploadDir, "icon.*")) {
+            for (Path iconFile : iconFiles) {
+                if (!iconFile.equals(currentIconPath)) {
+                    Files.deleteIfExists(iconFile);
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,3 +33,7 @@ spring.mail.port=1025
 spring.mail.properties.mail.smtp.auth=false
 spring.mail.properties.mail.smtp.starttls.enable=false
 app.mail.from=noreply@type-clash.local
+
+# --- ファイルアップロード設定 ---
+# ローカルではプロジェクト直下の uploads を使用し、本番では APP_UPLOAD_DIR で上書きする
+app.upload-dir=${APP_UPLOAD_DIR:uploads}


### PR DESCRIPTION
## 概要

ユーザーアイコン画像をアップロードし、ユーザー情報の `iconImage` として保存できるようにしました。

## 変更内容

- `POST /api/users/{userId}/icon` を追加
- アップロード画像を `uploads/users/{userId}/icon.{拡張子}` に保存
- `User.iconImage` に `/uploads/users/{userId}/icon.{拡張子}` を保存
- `png / jpg / jpeg / webp` の拡張子のみ許可
- 画像ファイル不正時の `InvalidImageFileException` を追加
- `InvalidImageFileException` を `400 Bad Request` として返すハンドリングを追加
- `/uploads/**` で保存済み画像を配信する設定を追加
- `app.upload-dir` を `APP_UPLOAD_DIR` で上書きできるように追加
- ローカル検証画像がPRに混ざらないよう `.gitignore` に `uploads/` を追加

- 本番環境では `APP_UPLOAD_DIR` の指定や永続化ボリュームなど、アップロード画像の保存先設定が必要です。