### PR TITLE
Redisで単一ログインセッションを管理

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/example/typing/config/SecurityConfig.java
+++ b/src/main/java/com/example/typing/config/SecurityConfig.java
@@ -36,11 +36,15 @@ public class SecurityConfig {
             .headers(headers -> headers
                 .frameOptions(frameOptions -> frameOptions.sameOrigin())
             ) //h2-consoleを使用できるように設定
+            .sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
 
 
             .authorizeHttpRequests(auth -> auth
                 .anyRequest().permitAll()
             );
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 

--- a/src/main/java/com/example/typing/config/SecurityConfig.java
+++ b/src/main/java/com/example/typing/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -42,7 +43,9 @@ public class SecurityConfig {
 
 
             .authorizeHttpRequests(auth -> auth
-                .anyRequest().permitAll()
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                .requestMatchers("/api/auth/**", "/h2-console/**").permitAll()
+                .anyRequest().authenticated()
             );
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/com/example/typing/controller/AuthController.java
+++ b/src/main/java/com/example/typing/controller/AuthController.java
@@ -20,6 +20,7 @@ import com.example.typing.service.LoginSessionService;
 import com.example.typing.service.TwoFactorAuthService;
 import com.example.typing.service.UserService;
 
+import io.jsonwebtoken.Claims;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -103,9 +104,10 @@ public class AuthController {
          */
         @PostMapping("/auth/logout")
         public ResponseEntity<?> logout(@CookieValue(name = "accessToken", required = false) String accessToken) {
-                if (accessToken != null && jwtUtils.validateToken(accessToken)) {
-                        Long userId = jwtUtils.getUserIdFromToken(accessToken);
-                        String loginSessionId = jwtUtils.getLoginSessionIdFromToken(accessToken);
+                Claims claims = accessToken == null ? null : jwtUtils.validateAndGetClaims(accessToken);
+                if (claims != null) {
+                        Long userId = Long.parseLong(claims.getSubject());
+                        String loginSessionId = claims.get("loginSessionId", String.class);
                         loginSessionService.deleteSessionIfMatches(userId, loginSessionId);
                 }
                 ResponseCookie cookie = ResponseCookie.from("accessToken", "")

--- a/src/main/java/com/example/typing/controller/AuthController.java
+++ b/src/main/java/com/example/typing/controller/AuthController.java
@@ -16,6 +16,7 @@ import com.example.typing.dto.response.UserResponse;
 import com.example.typing.entity.User;
 import com.example.typing.security.JwtUtils;
 import com.example.typing.service.AuthService;
+import com.example.typing.service.LoginSessionService;
 import com.example.typing.service.TwoFactorAuthService;
 import com.example.typing.service.UserService;
 
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 public class AuthController {
         private final JwtUtils jwtUtils;
         private final AuthService authService;
+        private final LoginSessionService loginSessionService;
         private final TwoFactorAuthService twoFactorAuthService;
         private final UserService userService;
 
@@ -100,7 +102,12 @@ public class AuthController {
          * @return
          */
         @PostMapping("/auth/logout")
-        public ResponseEntity<?> logout() {
+        public ResponseEntity<?> logout(@CookieValue(name = "accessToken", required = false) String accessToken) {
+                if (accessToken != null && jwtUtils.validateToken(accessToken)) {
+                        Long userId = jwtUtils.getUserIdFromToken(accessToken);
+                        String loginSessionId = jwtUtils.getLoginSessionIdFromToken(accessToken);
+                        loginSessionService.deleteSessionIfMatches(userId, loginSessionId);
+                }
                 ResponseCookie cookie = ResponseCookie.from("accessToken", "")
                                 .httpOnly(true)
                                 // .secure(true) //HTTPS通信のみで送信
@@ -126,7 +133,8 @@ public class AuthController {
         public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
 
                 User user = authService.authenticate(request);
-                String token = jwtUtils.generateToken(user.getId());
+                String loginSessionId = loginSessionService.createSession(user.getId());
+                String token = jwtUtils.generateToken(user.getId(), loginSessionId);
 
                 ResponseCookie cookie = ResponseCookie.from("accessToken", token)
                                 .httpOnly(true)

--- a/src/main/java/com/example/typing/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/typing/security/JwtAuthenticationFilter.java
@@ -11,6 +11,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.example.typing.service.LoginSessionService;
 
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -42,31 +43,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
         String token = parseJwt(request);
 
-        if (token != null && jwtUtils.validateToken(token)) {
-            Long userId = jwtUtils.getUserIdFromToken(token);
-            String loginSessionId = jwtUtils.getLoginSessionIdFromToken(token);
-            if (!loginSessionService.isValid(userId, loginSessionId)) {
-                if (isAuthEndpoint(request)) {
-                    filterChain.doFilter(request, response);
-                    return;
+        if (token != null) {
+            Claims claims = jwtUtils.validateAndGetClaims(token);
+            if (claims != null) {
+                Long userId = Long.parseLong(claims.getSubject());
+                String loginSessionId = claims.get("loginSessionId", String.class);
+                if (loginSessionService.isValid(userId, loginSessionId)) {
+                    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId,
+                            null, Collections.emptyList());
+
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                } else {
+                    SecurityContextHolder.clearContext();
                 }
+            } else {
                 SecurityContextHolder.clearContext();
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                return;
             }
-
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId,
-                    null, Collections.emptyList());
-
-            SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 
         filterChain.doFilter(request, response);
 
-    }
-
-    private boolean isAuthEndpoint(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        return path != null && path.startsWith("/api/auth/");
     }
 }

--- a/src/main/java/com/example/typing/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/typing/security/JwtAuthenticationFilter.java
@@ -41,27 +41,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String token = parseJwt(request);
+        try {
+            String token = parseJwt(request);
+            if (token == null)
+                return;
 
-        if (token != null) {
             Claims claims = jwtUtils.validateAndGetClaims(token);
-            if (claims != null) {
-                Long userId = Long.parseLong(claims.getSubject());
-                String loginSessionId = claims.get("loginSessionId", String.class);
-                if (loginSessionService.isValid(userId, loginSessionId)) {
-                    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId,
-                            null, Collections.emptyList());
-
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
-                } else {
-                    SecurityContextHolder.clearContext();
-                }
-            } else {
+            if (claims == null) {
                 SecurityContextHolder.clearContext();
+                return;
             }
+
+            Long userId = Long.parseLong(claims.getSubject());
+            String loginSessionId = claims.get("loginSessionId", String.class);
+            if (!loginSessionService.isValid(userId, loginSessionId)) {
+                SecurityContextHolder.clearContext();
+                return;
+            }
+
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null,
+                    Collections.emptyList());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        } finally {
+            filterChain.doFilter(request, response);
         }
-
-        filterChain.doFilter(request, response);
-
     }
 }

--- a/src/main/java/com/example/typing/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/typing/security/JwtAuthenticationFilter.java
@@ -9,6 +9,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.example.typing.service.LoginSessionService;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,9 +19,11 @@ import jakarta.servlet.http.HttpServletResponse;
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtUtils jwtUtils;
+    private final LoginSessionService loginSessionService;
 
-    public JwtAuthenticationFilter(JwtUtils jwtUtils) {
+    public JwtAuthenticationFilter(JwtUtils jwtUtils, LoginSessionService loginSessionService) {
         this.jwtUtils = jwtUtils;
+        this.loginSessionService = loginSessionService;
     }
 
     private String parseJwt(HttpServletRequest request) {
@@ -40,6 +44,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (token != null && jwtUtils.validateToken(token)) {
             Long userId = jwtUtils.getUserIdFromToken(token);
+            String loginSessionId = jwtUtils.getLoginSessionIdFromToken(token);
+            if (!loginSessionService.isValid(userId, loginSessionId)) {
+                if (isAuthEndpoint(request)) {
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+                SecurityContextHolder.clearContext();
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
 
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId,
                     null, Collections.emptyList());
@@ -49,5 +63,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         filterChain.doFilter(request, response);
 
+    }
+
+    private boolean isAuthEndpoint(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path != null && path.startsWith("/api/auth/");
     }
 }

--- a/src/main/java/com/example/typing/security/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/example/typing/security/JwtHandshakeInterceptor.java
@@ -10,13 +10,17 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 
+import com.example.typing.service.LoginSessionService;
+
 @Component
 public class JwtHandshakeInterceptor implements HandshakeInterceptor {
 
     private final JwtUtils jwtUtils;
+    private final LoginSessionService loginSessionService;
 
-    public JwtHandshakeInterceptor(JwtUtils jwtUtils) {
+    public JwtHandshakeInterceptor(JwtUtils jwtUtils, LoginSessionService loginSessionService) {
         this.jwtUtils = jwtUtils;
+        this.loginSessionService = loginSessionService;
     }
 
     @Override
@@ -38,7 +42,14 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
         }
 
         Long userId = jwtUtils.getUserIdFromToken(token);
+        String loginSessionId = jwtUtils.getLoginSessionIdFromToken(token);
+        if (!loginSessionService.isValid(userId, loginSessionId)) {
+            response.setStatusCode(HttpStatus.UNAUTHORIZED);
+            return false;
+        }
+
         attributes.put(WebSocketAuthHelper.WS_USER_ID_ATTR, userId);
+        attributes.put(WebSocketAuthHelper.WS_LOGIN_SESSION_ID_ATTR, loginSessionId);
         return true;
     }
 

--- a/src/main/java/com/example/typing/security/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/example/typing/security/JwtHandshakeInterceptor.java
@@ -12,6 +12,8 @@ import org.springframework.web.socket.server.HandshakeInterceptor;
 
 import com.example.typing.service.LoginSessionService;
 
+import io.jsonwebtoken.Claims;
+
 @Component
 public class JwtHandshakeInterceptor implements HandshakeInterceptor {
 
@@ -36,13 +38,14 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
 
         String token = WebSocketAuthHelper.parseAccessToken(
                 servletRequest.getServletRequest().getCookies());
-        if (token == null || !jwtUtils.validateToken(token)) {
+        Claims claims = token == null ? null : jwtUtils.validateAndGetClaims(token);
+        if (claims == null) {
             response.setStatusCode(HttpStatus.UNAUTHORIZED);
             return false;
         }
 
-        Long userId = jwtUtils.getUserIdFromToken(token);
-        String loginSessionId = jwtUtils.getLoginSessionIdFromToken(token);
+        Long userId = Long.parseLong(claims.getSubject());
+        String loginSessionId = claims.get("loginSessionId", String.class);
         if (!loginSessionService.isValid(userId, loginSessionId)) {
             response.setStatusCode(HttpStatus.UNAUTHORIZED);
             return false;

--- a/src/main/java/com/example/typing/security/JwtUtils.java
+++ b/src/main/java/com/example/typing/security/JwtUtils.java
@@ -21,6 +21,7 @@ public class JwtUtils {
 
     private static final long EXPIRATION_TIME = 1000 * 60 * 60 * 24;
     private static final long OTP_TOKEN_EXPIRY = 1000 * 60 * 10;
+    private static final String LOGIN_SESSION_ID_CLAIM = "loginSessionId";
 
     /**
      * 【JWT署名キーの取得】
@@ -37,12 +38,13 @@ public class JwtUtils {
      * @param id
      * @return
      */
-    public String generateToken(Long id) {
+    public String generateToken(Long id, String loginSessionId) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + EXPIRATION_TIME);
 
         return Jwts.builder()
                 .setSubject(String.valueOf(id))
+                .claim(LOGIN_SESSION_ID_CLAIM, loginSessionId)
                 .setIssuedAt(now)
                 .setExpiration(expiryDate)
                 .signWith(getKey())
@@ -74,13 +76,12 @@ public class JwtUtils {
      * @return
      */
     public Long getUserIdFromToken(String token) {
-        String subject = Jwts.parserBuilder()
-                .setSigningKey(getKey())
-                .build()
-                .parseClaimsJws(token)
-                .getBody()
-                .getSubject();
+        String subject = getClaims(token).getSubject();
         return Long.parseLong(subject);
+    }
+
+    public String getLoginSessionIdFromToken(String token) {
+        return getClaims(token).get(LOGIN_SESSION_ID_CLAIM, String.class);
     }
 
     /**
@@ -159,17 +160,21 @@ public class JwtUtils {
      * @throws JwtException トークンが無効な場合
      */
     private String getEmailFromScopedToken(String token, String expectedScope) {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(getKey())
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+        Claims claims = getClaims(token);
 
         if (!expectedScope.equals(claims.get("scope"))) {
             throw new JwtException("Invalid token scope");
         }
 
         return claims.getSubject();
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
     }
 
 }

--- a/src/main/java/com/example/typing/security/JwtUtils.java
+++ b/src/main/java/com/example/typing/security/JwtUtils.java
@@ -59,13 +59,18 @@ public class JwtUtils {
      */
 
     public boolean validateToken(String token) {
+        return validateAndGetClaims(token) != null;
+    }
+
+    public Claims validateAndGetClaims(String token) {
         try {
-            Claims claims = Jwts.parserBuilder()
-                    .setSigningKey(getKey()).build()
-                    .parseClaimsJws(token).getBody();
-            return claims.get("scope") == null;
+            Claims claims = getClaims(token);
+            if (claims.get("scope") != null) {
+                return null;
+            }
+            return claims;
         } catch (JwtException | IllegalArgumentException e) {
-            return false;
+            return null;
         }
     }
 

--- a/src/main/java/com/example/typing/security/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/example/typing/security/StompAuthChannelInterceptor.java
@@ -14,6 +14,7 @@ import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
 import com.example.typing.service.BattleModeService;
+import com.example.typing.service.LoginSessionService;
 
 @Component
 public class StompAuthChannelInterceptor implements ChannelInterceptor {
@@ -22,9 +23,13 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
     private static final String BATTLE_TOPIC_PREFIX = "/topic/battle/";
 
     private final BattleModeService battleModeService;
+    private final LoginSessionService loginSessionService;
 
-    public StompAuthChannelInterceptor(@Lazy BattleModeService battleModeService) {
+    public StompAuthChannelInterceptor(
+            @Lazy BattleModeService battleModeService,
+            LoginSessionService loginSessionService) {
         this.battleModeService = battleModeService;
+        this.loginSessionService = loginSessionService;
     }
 
     @Override
@@ -37,7 +42,10 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
         if (StompCommand.CONNECT.equals(accessor.getCommand())) {
             handleConnect(accessor);
         } else if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+            validateCurrentLoginSession(accessor);
             handleSubscribe(accessor);
+        } else if (StompCommand.SEND.equals(accessor.getCommand())) {
+            validateCurrentLoginSession(accessor);
         }
 
         return message;
@@ -124,6 +132,26 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
         }
         if (value instanceof Number number) {
             return number.longValue();
+        }
+        return null;
+    }
+
+    private void validateCurrentLoginSession(StompHeaderAccessor accessor) {
+        Long userId = WebSocketAuthHelper.getUserIdFromPrincipal(accessor.getUser());
+        String loginSessionId = getHandshakeLoginSessionId(accessor);
+        if (!loginSessionService.isValid(userId, loginSessionId)) {
+            throw new MessageDeliveryException("Unauthorized: inactive login session");
+        }
+    }
+
+    private String getHandshakeLoginSessionId(StompHeaderAccessor accessor) {
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+        if (sessionAttributes == null) {
+            return null;
+        }
+        Object value = sessionAttributes.get(WebSocketAuthHelper.WS_LOGIN_SESSION_ID_ATTR);
+        if (value instanceof String loginSessionId) {
+            return loginSessionId;
         }
         return null;
     }

--- a/src/main/java/com/example/typing/security/WebSocketAuthHelper.java
+++ b/src/main/java/com/example/typing/security/WebSocketAuthHelper.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.Cookie;
 public final class WebSocketAuthHelper {
 
     public static final String WS_USER_ID_ATTR = "wsUserId";
+    public static final String WS_LOGIN_SESSION_ID_ATTR = "wsLoginSessionId";
 
     private WebSocketAuthHelper() {
     }

--- a/src/main/java/com/example/typing/service/LoginSessionService.java
+++ b/src/main/java/com/example/typing/service/LoginSessionService.java
@@ -1,0 +1,52 @@
+package com.example.typing.service;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LoginSessionService {
+
+    private static final Duration SESSION_TTL = Duration.ofHours(24);
+    private static final String LOGIN_SESSION_KEY_PREFIX = "login:user:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    public LoginSessionService(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public String createSession(Long userId) {
+        String loginSessionId = UUID.randomUUID().toString();
+        redisTemplate.opsForValue().set(buildKey(userId), loginSessionId, SESSION_TTL);
+        return loginSessionId;
+    }
+
+    public boolean isValid(Long userId, String loginSessionId) {
+        if (userId == null || loginSessionId == null || loginSessionId.isBlank()) {
+            return false;
+        }
+        String currentSessionId = redisTemplate.opsForValue().get(buildKey(userId));
+        return loginSessionId.equals(currentSessionId);
+    }
+
+    public void deleteSession(Long userId) {
+        if (userId == null) {
+            return;
+        }
+        redisTemplate.delete(buildKey(userId));
+    }
+
+    public void deleteSessionIfMatches(Long userId, String loginSessionId) {
+        if (!isValid(userId, loginSessionId)) {
+            return;
+        }
+        deleteSession(userId);
+    }
+
+    private String buildKey(Long userId) {
+        return LOGIN_SESSION_KEY_PREFIX + userId;
+    }
+}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -13,3 +13,8 @@ spring.mail.properties.mail.smtp.timeout=10000
 spring.mail.properties.mail.smtp.writetimeout=10000
 
 app.mail.from=${APP_MAIL_FROM}
+
+# --- Redis settings for active login sessions ---
+spring.data.redis.host=${REDIS_HOST}
+spring.data.redis.port=${REDIS_PORT:6379}
+spring.data.redis.repositories.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,11 @@ spring.jpa.show-sql=true
 
 server.port=8080
 
+# --- Redis設定（ログインセッション管理用） ---
+spring.data.redis.host=${REDIS_HOST:localhost}
+spring.data.redis.port=${REDIS_PORT:6379}
+spring.data.redis.repositories.enabled=false
+
 # JWT認証用秘密鍵
 jwt.secret=y8YYuiqQc/B1f+es4RxSNziSJcIPVjouX8aKY1JZPlE=
 


### PR DESCRIPTION
概要
同一アカウントで複数端末から同時ログインできる問題に対応しました。

Redis にユーザーごとの有効な loginSessionId を保存し、JWT に含まれる loginSessionId と照合することで、後からログインした端末のみを有効にします。

主な変更内容
Redis 依存関係を追加
Redis 接続設定を追加
ログイン成功時に loginSessionId を発行し、Redis に保存
JWT に loginSessionId を含めるよう修正
REST API 認証時に JWT の loginSessionId と Redis の値を照合
2台目ログイン後、1台目のJWTを無効扱いにするよう修正
ログアウト時に Redis のログインセッションを削除
WebSocket 接続・送信・購読時にもログインセッションを照合
補足
Redis には以下の形式で現在有効なログインセッションを保存します。

login:user:{userId} = {loginSessionId}
本番環境では Redis の接続先を環境変数で設定します。

REDIS_HOST
REDIS_PORT
動作確認
./mvnw test 実行済み
テスト成功確認済み